### PR TITLE
Fix glyph grid padding on smaller viewports

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -46,6 +46,7 @@ body {
 .container {
   max-width: 1400px;
   margin: 0 auto;
+  padding: 0 1rem;
   min-height: 100vh;
   display: flex;
   flex-direction: column;
@@ -642,6 +643,10 @@ body {
 
 /* Responsive Design */
 @media (max-width: 768px) {
+  .container {
+    padding: 0 1.5rem;
+  }
+
   .header-content {
     padding: 0 1rem;
   }


### PR DESCRIPTION
## Summary
- Adds horizontal padding to the main container to prevent glyph cards from touching viewport edges
- Improves spacing when browser window is resized or zoomed beyond 100%
- Enhanced mobile padding for better user experience

## Changes
- Added `padding: 0 1rem` to `.container` class
- Increased mobile padding to `1.5rem` for screens ≤768px wide

## Test plan
- [x] Tested on desktop with normal viewport
- [x] Tested with resized browser window (sidebar scenarios)
- [x] Tested with browser zoom at 110%, 125%, 150%
- [x] Verified mobile responsive behavior

Fixes #1

🤖 Generated with [Claude Code](https://claude.ai/code)