### PR TITLE
chore(deps): update ucd-full to v17 for Unicode 17 data

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,24 +1,24 @@
 {
   "name": "glyph-party",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "glyph-party",
-      "version": "0.0.1",
+      "version": "0.1.0",
       "license": "MIT",
       "devDependencies": {
-        "ucd-full": "^16.0.1"
+        "ucd-full": "^17.0.0"
       },
       "engines": {
         "node": ">=16.0.0"
       }
     },
     "node_modules/ucd-full": {
-      "version": "16.0.1",
-      "resolved": "https://registry.npmjs.org/ucd-full/-/ucd-full-16.0.1.tgz",
-      "integrity": "sha512-XnDN5vR6TNr0+2Tp4mAl5J59HZLji1IhWbIwvTD6G1mpzz4Vjg8vjyBm7VNyd+D/fnDridl9/cTHIKMXojvdeA==",
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/ucd-full/-/ucd-full-17.0.0.tgz",
+      "integrity": "sha512-2gDrJmeiVwzRYfhSje3c4H7ZjRsE2hlkIf9+CbyCwdY1rp+pzm6wAMD92Yi2P2mdEsrWZJU0SIUruhDiXY8kuA==",
       "dev": true,
       "license": "Apache-2.0"
     }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "author": "Your Name",
   "license": "MIT",
   "devDependencies": {
-    "ucd-full": "^16.0.1"
+    "ucd-full": "^17.0.0"
   },
   "engines": {
     "node": ">=16.0.0"


### PR DESCRIPTION
- Upgrade ucd-full from 16.0.1 to 17.0.0
- Bump project version to 0.1.0

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated ucd-full to 17.0.0 to use Unicode 17 data. Also bumped the project version to 0.1.0.

<sup>Written for commit 90485cf6dd865dfae86ff2e3138217e0d6d86324. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

