### PR TITLE
feat(search): add multi-term search with AND logic

### DIFF
--- a/src/script.js
+++ b/src/script.js
@@ -178,15 +178,25 @@ class GlyphParty {
     this.filteredCharacters = this.characters.filter((char) => {
       // Search filter
       if (this.currentSearch) {
-        const searchTerm = this.currentSearch;
-        const matchesName = char.name.toLowerCase().includes(searchTerm);
-        const matchesCode = char.code.toLowerCase().includes(searchTerm);
-        const matchesChar = char.char.includes(searchTerm);
-        const matchesDesc = char.description
-          ?.toLowerCase()
-          .includes(searchTerm);
+        const searchTerms = this.currentSearch
+          .trim()
+          .split(/\s+/)
+          .filter(Boolean);
 
-        if (!matchesName && !matchesCode && !matchesChar && !matchesDesc) {
+        // Build combined searchable text
+        const searchableText = [
+          char.name.toLowerCase(),
+          char.code.toLowerCase(),
+          char.char,
+          char.description?.toLowerCase() || "",
+        ].join(" ");
+
+        // All terms must match (AND logic)
+        const allTermsMatch = searchTerms.every((term) =>
+          searchableText.includes(term),
+        );
+
+        if (!allTermsMatch) {
           return false;
         }
       }


### PR DESCRIPTION
- Split search input by whitespace to support multiple terms
- Require all terms to match (AND logic) instead of any term (OR)
- Combine name, code, char, and description into searchable text Enables precise filtering like "arrow left" to find left-pointing arrows.

Closes #7

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds multi‑term search with AND logic so results must match all terms across name, code, character, and description. This enables precise queries like "arrow left" to find left‑pointing arrows.

- **New Features**
  - Tokenizes input by whitespace and requires every term to match (AND).
  - Combines name, code, char, and description into one lowercase searchable string.

<sup>Written for commit 1c552017277727ddb4e608064453cb39ef989bd4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

