### PR TITLE
chore(release): bump version to 0.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "glyph-party",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "A beautiful Unicode character search tool for terminal developers",
   "main": "src/index.html",
   "scripts": {

--- a/src/index.html
+++ b/src/index.html
@@ -56,7 +56,7 @@
             <h1 class="title">
               <span class="title-glyph">✨</span>
               Glyph Party
-              <span class="title-version" id="glyph-party-version">v0.1.2</span>
+              <span class="title-version" id="glyph-party-version"></span>
             </h1>
             <button
               id="theme-toggle"

--- a/src/index.html
+++ b/src/index.html
@@ -56,7 +56,7 @@
             <h1 class="title">
               <span class="title-glyph">✨</span>
               Glyph Party
-              <span class="title-version" id="glyph-party-version">v1.0</span>
+              <span class="title-version" id="glyph-party-version">v0.1.2</span>
             </h1>
             <button
               id="theme-toggle"


### PR DESCRIPTION
- Update package.json version
- Sync displayed version in HTML
- Version now read from unicode-data.json at runtime
- Single source of truth is package.json